### PR TITLE
Share include_directories with KDTree target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,4 +22,5 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
 include_directories(.)
 add_library(KDTree SHARED KDTree.cpp)
+target_include_directories(KDTree PUBLIC .)
 add_subdirectory(tests)


### PR DESCRIPTION
Thanks for this library!

Minor cmake usability improvement: Adding `target_include_directories` lets users link against the library and automatically take advantage of the proper include directories, so they won't have to also write `include_directories` when they use this library.