### PR TITLE
4x speed improvement

### DIFF
--- a/KDTree.hpp
+++ b/KDTree.hpp
@@ -108,11 +108,12 @@ class KDTree {
     pointIndex nearest_pointIndex(const point_t &pt);
 
    private:
-    pointIndexArr neighborhood_(  //
+    void neighborhood_(  //
         const KDNodePtr &branch,  //
         const point_t &pt,        //
         const double &rad,        //
-        const size_t &level       //
+        const size_t &level,      //
+	pointIndexArr& nbh
     );
 
    public:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Compiler settings
+CXX = g++
+CXXFLAGS = -std=c++17 -Wall
+
+# Targets
+all: KDTree
+
+KDTree: KDTree.o
+	ar rvs libKDTree.a KDTree.o
+
+KDTree.o: KDTree.cpp KDTree.hpp
+	$(CXX) $(CXXFLAGS) -c KDTree.cpp
+
+install: KDTree
+	mkdir -p lib
+	mv libKDTree.a lib/
+
+clean:
+	rm -f KDTree.o libKDTree.a
+	rm -rf lib

--- a/tests/construction_time.cpp
+++ b/tests/construction_time.cpp
@@ -35,7 +35,7 @@ std::vector<std::vector<double>> getListofGeneratedVectors(size_t length)
 	return temp;
 }
 
-snt main()
+int main()
 {
     // seed
 	srand(5);
@@ -43,9 +43,9 @@ snt main()
     size_t npoints = 400000;
     std::cout << "constructing KDTree with " << npoints << " points." << std::endl;
 
-    td::vector<point_t> points = getListofGeneratedVectors(npoints);
+    std::vector<point_t> points = getListofGeneratedVectors(npoints);
 
-    uto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::high_resolution_clock::now();
     KDTree tree(points);
     auto stop = std::chrono::high_resolution_clock::now();
     auto timespan = std::chrono::duration<double>(stop - start);


### PR DESCRIPTION
Simple fix to pass `nbh` vector across `neighborhood_` calls rather than build new and transfer within each function. Saves a lot of unnecessary vector creation/destruction. Identical output, ~4x speed improvement (29m vs 6m on my use-case).