### PR TITLE
Fix insertion bug in node_query_

### DIFF
--- a/KDTree.cpp
+++ b/KDTree.cpp
@@ -135,6 +135,7 @@ void KDTree::node_query_(
         std::upper_bound(k_nearest_buffer.begin(), k_nearest_buffer.end(),
                          node_distance, detail::compare_node_distance);
     if (insert_it == k_nearest_buffer.end() ||
+        std::next(insert_it) == k_nearest_buffer.end() ||
         insert_it->first != std::next(insert_it)->first) {
         k_nearest_buffer.insert(insert_it, node_distance);
     }

--- a/KDTree.cpp
+++ b/KDTree.cpp
@@ -134,9 +134,8 @@ void KDTree::node_query_(
     auto const insert_it =
         std::upper_bound(k_nearest_buffer.begin(), k_nearest_buffer.end(),
                          node_distance, detail::compare_node_distance);
-    if (insert_it == k_nearest_buffer.end() ||
-        std::next(insert_it) == k_nearest_buffer.end() ||
-        insert_it->first != std::next(insert_it)->first) {
+    if (insert_it != k_nearest_buffer.end() ||
+        k_nearest_buffer.size() < num_nearest) {
         k_nearest_buffer.insert(insert_it, node_distance);
     }
     while (k_nearest_buffer.size() > num_nearest) {


### PR DESCRIPTION
Fix #12 

Fixed a bug in `KDTree::node_query_` that `k_nearest_buffer.insert()` might not be executed in certain environments when the next of `insert_it` is `k_nearest_buffer.end()`.